### PR TITLE
Removed redundant `date` field (use `created` and `modified` instead)

### DIFF
--- a/notes/migrations/0001_initial.py
+++ b/notes/migrations/0001_initial.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 from django.db import models, migrations
 import django.utils.timezone
-import datetime
 import django_extensions.db.fields
 from django.conf import settings
 
@@ -22,7 +21,6 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('created', django_extensions.db.fields.CreationDateTimeField(default=django.utils.timezone.now, verbose_name='created', editable=False, blank=True)),
                 ('modified', django_extensions.db.fields.ModificationDateTimeField(default=django.utils.timezone.now, verbose_name='modified', editable=False, blank=True)),
-                ('date', models.DateField(default=datetime.datetime(2015, 3, 30, 13, 39, 53, 299977), verbose_name='Date')),
                 ('content', models.TextField(verbose_name='Content')),
                 ('public', models.BooleanField(default=True, verbose_name='Public')),
                 ('object_id', models.PositiveIntegerField()),

--- a/notes/models.py
+++ b/notes/models.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
@@ -12,7 +11,6 @@ class Note(TimeStampedModel):
     """
     A simple model to handle adding arbitrary numbers of notes to a generic object.
     """
-    date = models.DateField(_('Date'), default=datetime.now())
     content = models.TextField(_('Content'))
     public = models.BooleanField(_('Public'), default=True)
     author = models.ForeignKey(User, blank=True, null=True)


### PR DESCRIPTION
The `date` field had a default of `now()` instead of `now`, which caused the default to change every time the process was started, and caused `makemigrations` to perpetually generate new migrations for the app.  It is also redundant because of the `TimeStampedModel` mixin.
