### PR TITLE
Removed dependency on django_extensions

### DIFF
--- a/notes/migrations/0001_initial.py
+++ b/notes/migrations/0001_initial.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 from django.db import models, migrations
 import django.utils.timezone
-import django_extensions.db.fields
 from django.conf import settings
 
 
@@ -19,8 +18,8 @@ class Migration(migrations.Migration):
             name='Note',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('created', django_extensions.db.fields.CreationDateTimeField(default=django.utils.timezone.now, verbose_name='created', editable=False, blank=True)),
-                ('modified', django_extensions.db.fields.ModificationDateTimeField(default=django.utils.timezone.now, verbose_name='modified', editable=False, blank=True)),
+                ('created', models.DateTimeField(default=django.utils.timezone.now, editable=False, verbose_name='created', blank=True)),
+                ('modified', models.DateTimeField(default=django.utils.timezone.now, editable=False, verbose_name='modified', blank=True)),
                 ('content', models.TextField(verbose_name='Content')),
                 ('public', models.BooleanField(default=True, verbose_name='Public')),
                 ('object_id', models.PositiveIntegerField()),

--- a/notes/models.py
+++ b/notes/models.py
@@ -3,8 +3,25 @@ from django.db import models
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
 from django.contrib.auth.models import User
+from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
-from django_extensions.db.models import TimeStampedModel
+
+
+class TimeStampedModel(models.Model):
+
+    created = models.DateTimeField(_('created'), default=now, editable=False, blank=True)
+    modified = models.DateTimeField(_('modified'), default=now, editable=False, blank=True)
+
+    class Meta:
+        abstract = True
+        get_latest_by = 'modified'
+        ordering = ('-modified', '-created',)
+
+    def save(self, *args, **kwargs):
+        self.modified = now()
+        if 'update_fields' in kwargs:
+            kwargs['update_fields'] += ('modified',)
+        super(TimeStampedModel, self).save(*args, **kwargs)
 
 
 class Note(TimeStampedModel):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def read(fname):
 
 setup(
     name="notes",
-    version="0.2.2",
+    version="0.3.0",
     description=DESCRIPTION,
     long_description=read("README.rst"),
     author="Colin Powell",
@@ -28,7 +28,7 @@ setup(
     url="http://github.com/powellc/django-notes/",
     packages=['notes'],
     install_requires=[
-        'django>=1.6'
+        'django>=1.7'
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
# Purpose

`django_extensions` had a bit of a migrations snafu (see: https://github.com/django-extensions/django-extensions/issues/733#issuecomment-140359189).  Also, the dependency on that library was not declared in the `setup.py` file in this package.  Let's write our own 8 lines of code to avoid that mess.
