### PR TITLE
Fixed import for GenericForeignKey

### DIFF
--- a/notes/models.py
+++ b/notes/models.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-from django.db import models
+
+from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes import generic
 from django.contrib.auth.models import User
+from django.db import models
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 
@@ -33,7 +34,7 @@ class Note(TimeStampedModel):
     author = models.ForeignKey(User, blank=True, null=True)
     content_type = models.ForeignKey(ContentType)
     object_id = models.PositiveIntegerField()
-    content_object = generic.GenericForeignKey("content_type", "object_id")
+    content_object = GenericForeignKey("content_type", "object_id")
 
     objects = models.Manager()
 


### PR DESCRIPTION
See: https://docs.djangoproject.com/en/1.8/ref/contrib/contenttypes/#django.contrib.contenttypes.fields.GenericForeignKey
