### PR TITLE
Django 2.0 support

### DIFF
--- a/notes/migrations/0001_initial.py
+++ b/notes/migrations/0001_initial.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from django.db import models, migrations
 import django.utils.timezone
 from django.conf import settings
+import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
@@ -23,8 +24,8 @@ class Migration(migrations.Migration):
                 ('content', models.TextField(verbose_name='Content')),
                 ('public', models.BooleanField(default=True, verbose_name='Public')),
                 ('object_id', models.PositiveIntegerField()),
-                ('author', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True)),
-                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
+                ('author', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=django.db.models.deletion.CASCADE)),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType', on_delete=django.db.models.deletion.CASCADE)),
             ],
             options={
                 'verbose_name': 'Note',

--- a/notes/models.py
+++ b/notes/models.py
@@ -31,8 +31,8 @@ class Note(TimeStampedModel):
     """
     content = models.TextField(_('Content'))
     public = models.BooleanField(_('Public'), default=True)
-    author = models.ForeignKey(User, blank=True, null=True)
-    content_type = models.ForeignKey(ContentType)
+    author = models.ForeignKey(User, blank=True, null=True, on_delete=models.SET_NULL)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
     content_object = GenericForeignKey("content_type", "object_id")
 

--- a/notes/models.py
+++ b/notes/models.py
@@ -31,7 +31,7 @@ class Note(TimeStampedModel):
     """
     content = models.TextField(_('Content'))
     public = models.BooleanField(_('Public'), default=True)
-    author = models.ForeignKey(User, blank=True, null=True, on_delete=models.SET_NULL)
+    author = models.ForeignKey(User, blank=True, null=True, on_delete=models.CASCADE)
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
     content_object = GenericForeignKey("content_type", "object_id")


### PR DESCRIPTION
Django 2.0 requires that foreign keys have explicit deletion behavior. This adds in said explicitness. Default behavior is cascade, so I kept it as the default.